### PR TITLE
Make JID optional in pubsub subscription options

### DIFF
--- a/include/xmpp_codec.hrl
+++ b/include/xmpp_codec.hrl
@@ -844,7 +844,7 @@
 -type pubsub_owner() :: #pubsub_owner{}.
 
 -record(ps_options, {node = <<>> :: binary(),
-                     jid :: jid:jid(),
+                     jid :: undefined | jid:jid(),
                      subid = <<>> :: binary(),
                      xdata :: 'undefined' | #xdata{}}).
 -type ps_options() :: #ps_options{}.

--- a/specs/xmpp_codec.spec
+++ b/specs/xmpp_codec.spec
@@ -2190,7 +2190,6 @@
            attrs = [#attr{name = <<"node">>},
                     #attr{name = <<"subid">>},
                     #attr{name = <<"jid">>,
-                          required = true,
                           dec = {jid, decode, []},
                           enc = {jid, encode, []}}],
            refs = [#ref{name = xdata, min = 0, max = 1,

--- a/src/xep0060.erl
+++ b/src/xep0060.erl
@@ -2687,8 +2687,7 @@ encode_pubsub_options_attr_subid(_val, _acc) ->
     [{<<"subid">>, _val} | _acc].
 
 decode_pubsub_options_attr_jid(__TopXMLNS, undefined) ->
-    erlang:error({xmpp_codec,
-		  {missing_attr, <<"jid">>, <<"options">>, __TopXMLNS}});
+    undefined;
 decode_pubsub_options_attr_jid(__TopXMLNS, _val) ->
     case catch jid:decode(_val) of
       {'EXIT', _} ->
@@ -2698,6 +2697,7 @@ decode_pubsub_options_attr_jid(__TopXMLNS, _val) ->
       _res -> _res
     end.
 
+encode_pubsub_options_attr_jid(undefined, _acc) -> _acc;
 encode_pubsub_options_attr_jid(_val, _acc) ->
     [{<<"jid">>, jid:encode(_val)} | _acc].
 


### PR DESCRIPTION
XEP-0060 states that 'node' and 'jid' attributes to <options> element MUST NOT
be included when <options> are specified at same time as <subscribe> :

https://xmpp.org/extensions/xep-0060.html#subscriber-configure-subandconfig

ps_options jid attribute is made optional, mod_pubsub will be updated to
enforce correct requirements in ejabberd