### PR TITLE
Use include_lib() to include headers from dependency

### DIFF
--- a/include/xmpp.hrl
+++ b/include/xmpp.hrl
@@ -25,7 +25,7 @@
 -include("ns.hrl").
 -include("jid.hrl").
 -include("xmpp_codec.hrl").
--include("fxml.hrl").
+-include_lib("fast_xml/include/fxml.hrl").
 
 -type stanza() :: iq() | presence() | message().
 

--- a/rebar.config
+++ b/rebar.config
@@ -22,9 +22,7 @@
 {erl_opts, [debug_info, {src_dirs, ["asn1", "src"]},
 	    nowarn_export_all,
             {platform_define, "^(R|1|20|21|22)", 'USE_OLD_CRYPTO_HMAC'},
-            {i, "include"},
-            {i, "../fast_xml/include"},
-            {i, "deps/fast_xml/include"}]}.
+            {i, "include"}]}.
 
 {port_env, [{"ERL_LDFLAGS", " -L$ERL_EI_LIBDIR -lei"},
             {"CFLAGS", "$CFLAGS"}, {"LDFLAGS", "$LDFLAGS"}]}.


### PR DESCRIPTION
Very similar to pull request #3 but this also tidies up rebar.config a little (and I have signed the CLA)