### PR TITLE
PR_erlang-p1-xmpp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+arch:
+  - ppc64le
+  - amd64
 language: erlang
 
 os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ arch:
   - ppc64le
   - amd64
 language: erlang
+before_install:
+  - if [ "$TRAVIS_ARCH" = "ppc64le" ]; then sudo apt-get update; sudo apt-get install rebar; fi
 
 os: linux
 
@@ -17,3 +19,11 @@ otp_release:
   - 19.3
   - 22.3
   - 23.0
+
+# Disable otp_release 18.3 & 19.3 as these releases are not supported on Ubuntu16.04 for arch: ppc64le
+jobs: 
+ exclude:
+  - arch: ppc64le
+    otp_release: 19.0
+  - arch: ppc64le
+    otp_release: 19.3


### PR DESCRIPTION
Adding power support ppc64le

This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.

Excluding Jobs for otp_releases:19.0/19.3 as these are not supported on Ubuntu16.04 with arch: ppc64le
Please refer to the link: https://docs.travis-ci.com/user/languages/erlang/#otprelease-versions

The build is successful for rest all(including arch: ppc64le/amd64). Pleas refer to Travis link: https://travis-ci.com/github/santosh653/xmpp
