### PR TITLE
Support rebar3 projects that use xmpp as a dependency

### DIFF
--- a/src/xmpp.app.src
+++ b/src/xmpp.app.src
@@ -27,7 +27,7 @@
   {vsn,          "1.5.1"},
   {modules,      []},
   {registered,   []},
-  {applications, [kernel, stdlib]},
+  {applications, [kernel, stdlib, stringprep, fast_xml, idna, ezlib, fast_tls]},
   {mod,          {xmpp, []}},
   {env,          []},
 

--- a/src/xmpp.erl
+++ b/src/xmpp.erl
@@ -113,10 +113,6 @@
 %%%===================================================================
 start(_StartType, _StartArgs) ->
     try
-	{ok, _} = application:ensure_all_started(fast_xml),
-	{ok, _} = application:ensure_all_started(stringprep),
-	{ok, _} = application:ensure_all_started(fast_tls),
-	{ok, _} = application:ensure_all_started(ezlib),
 	ok = jid:start(),
 	ok = xmpp_uri:start(),
 	ok = xmpp_lang:start(),


### PR DESCRIPTION
Hello,

While generating a release for an Erlang project using rebar3 and setting ejabberd as a dependency, I came across an issue on application startup. It seems the release script generated by rebar3/relx looks at the "xmpp.app.src" file to include libraries for startup. I wanted to submit a PR on the changes I made to get this issue resolved.

Cheers,
Michael