### PR TITLE
Adds GSSAPI SASL mechanism

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -36,7 +36,8 @@
 	{fast_tls, ".*", {git, "https://github.com/processone/fast_tls", {tag, "1.1.11"}}},
 	{ezlib, ".*", {git, "https://github.com/processone/ezlib", {tag, "1.0.9"}}},
 	{idna, ".*", {git, "https://github.com/benoitc/erlang-idna", {tag, "6.0.0"}}},
-        {stringprep, ".*", {git, "https://github.com/processone/stringprep", {tag, "1.0.24"}}}]}.
+	{stringprep, ".*", {git, "https://github.com/processone/stringprep", {tag, "1.0.24"}}},
+	{egssapi, ".*", {git, "https://github.com/dequbed/egssapi", {ref, "0.1.0"}}}]}.
 
 {clean_files, ["c_src/jid.gcda", "c_src/jid.gcno"]}.
 

--- a/src/xmpp.app.src
+++ b/src/xmpp.app.src
@@ -27,7 +27,7 @@
   {vsn,          "1.5.2"},
   {modules,      []},
   {registered,   []},
-  {applications, [kernel, stdlib, ezlib, fast_tls, fast_xml, idna, p1_utils, stringprep]},
+  {applications, [kernel, stdlib, ezlib, fast_tls, fast_xml, idna, p1_utils, stringprep, egssapi]},
   {mod,          {xmpp, []}},
   {env,          []},
 

--- a/src/xmpp_sasl.erl
+++ b/src/xmpp_sasl.erl
@@ -37,7 +37,7 @@
 -type mech_state() :: term().
 -type sasl_module() :: xmpp_sasl_anonymous | xmpp_sasl_digest |
 		       xmpp_sasl_oauth | xmpp_sasl_plain |
-		       xmpp_sasl_scram.
+		       xmpp_sasl_scram | xmpp_sasl_gssapi.
 -type sasl_state() :: #sasl_state{}.
 -type sasl_property() :: {username, binary()} |
 			 {authzid, binary()} |
@@ -90,7 +90,7 @@ listmech() ->
      <<"SCRAM-SHA-512-PLUS">>, <<"SCRAM-SHA-512">>,
      <<"SCRAM-SHA-256-PLUS">>, <<"SCRAM-SHA-256">>,
      <<"SCRAM-SHA-1-PLUS">>, <<"SCRAM-SHA-1">>,
-     <<"X-OAUTH2">>].
+     <<"X-OAUTH2">>, <<"GSSAPI">>].
 
 -spec server_new(binary(),
 		 get_password_fun(),
@@ -164,4 +164,5 @@ get_mod(<<"SCRAM-SHA-256-PLUS">>) -> xmpp_sasl_scram;
 get_mod(<<"SCRAM-SHA-256">>) -> xmpp_sasl_scram;
 get_mod(<<"SCRAM-SHA-512">>) -> xmpp_sasl_scram;
 get_mod(<<"SCRAM-SHA-512-PLUS">>) -> xmpp_sasl_scram;
+get_mod(<<"GSSAPI">>) -> xmpp_gssapi;
 get_mod(_) -> undefined.

--- a/src/xmpp_sasl_gssapi.erl
+++ b/src/xmpp_sasl_gssapi.erl
@@ -1,0 +1,50 @@
+%%%-------------------------------------------------------------------
+%%% @author Gregor Reitzenstein <me@dequbed.space>
+%%% @copyright (C) 2021, Gregor Reitzenstein
+%%%
+%%% Licensed under the Apache License, Version 2.0 (the "License");
+%%% you may not use this file except in compliance with the License.
+%%% You may obtain a copy of the License at
+%%%
+%%%     http://www.apache.org/licenses/LICENSE-2.0
+%%%
+%%% Unless required by applicable law or agreed to in writing, software
+%%% distributed under the License is distributed on an "AS IS" BASIS,
+%%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%%% See the License for the specific language governing permissions and
+%%% limitations under the License.
+%%%
+%%%-------------------------------------------------------------------
+
+-module(xmpp_sasl_gssapi).
+-behaviour(xmpp_sasl).
+-author('me@dequbed.space').
+
+%% API
+-export([mech_new/6, mech_step/2]).
+
+-record(state, {server = undefined}).
+
+mech_new(_Mech, _Socket, _Host, _GetPassword, _CheckPassword, _CheckPasswordDigest) ->
+    % TODO: Get an alternative keytab location from the config
+    {ok, Server} = egssapi:start_link(),
+    #state{server = Server}.
+
+mech_step(#state{server = Server} = State, ClientIn) ->
+    ClientInDec = base64:decode(ClientIn),
+    Result = egssapi:accept_sec_context(Server, ClientInDec),
+
+    case Result of
+        {ok, {Context, User, _Ccname, Resp}} ->
+            egssapi:delete_sec_context(Context),
+            if
+                Resp /= <<"">> ->
+                    {ok, [{authzid, User}, {username, User}], Resp};
+                true ->
+                    {ok, [{authzid, User}, {username, User}]}
+            end;
+        {needsmore, {Context, Resp}} ->
+            {continue, Resp, State#state{server = Context}};
+        {error, Error} ->
+            {error, Error}
+    end.


### PR DESCRIPTION
This is a WIP patch to bring GSSAPI-based authentication into this library and ultimately into ejabberd.

### Current issues:
- Due to limitations in the underlying egssapi library only Kerberos v5 is supported
- This patch has only been tested on x86-64 Linux. Since GSSAPI is platform- and architecture-independent it should work on other platforms as well however.
- According to [RFC 4752](https://tools.ietf.org/html/rfc4752#section-3.2) a server `MUST NOT` advertise the GSSAPI mechanism if it can't authenticate as the requested service/host principal. There's currently no mechanism to indicate availability of GSSAPI on a per-host basis.
- The afformentioned RFC 4752 notes a number of `SHOULD`/`SHOULD NOT`s this patch currently ignores, e.g. aquisition of credentials. Most of them are limitations in the underlying egssapi library.

Main reason for opening this PR is to give current work being done more visibility given processone/ejabberd#1586 processone/ejabberd#1595 and the entire discussion around that.

### TODOs

- [ ] Expose more API surface in egssapi. Mostly auxiliary functions like `gss_acquire_cred` that would be nice to have.
- [ ] Improve the NIF code. The C code is currently taken straight from [mikma/egssapi](https://github.com/mikma/egssapi). Additioal work should be put into ensuring it's safe, or — depending on platform availability requirements — rewrite it in Rust.
- [ ] Documentation. GSSAPI has some rather nasty quirks one needs to be aware of.