### PR TITLE
MIX improvements

### DIFF
--- a/include/xmpp_codec.hrl
+++ b/include/xmpp_codec.hrl
@@ -319,9 +319,6 @@
 -record(db_feature, {errors = false :: boolean()}).
 -type db_feature() :: #db_feature{}.
 
--record(mix_roster_annotate, {}).
--type mix_roster_annotate() :: #mix_roster_annotate{}.
-
 -record(x_conference, {jid :: jid:jid(),
                        password = <<>> :: binary(),
                        reason = <<>> :: binary(),
@@ -913,7 +910,7 @@
                       xmlns = <<>> :: binary()}).
 -type mix_setnick() :: #mix_setnick{}.
 
--record(mix_roster_channel, {'participant-id' = <<>> :: binary()}).
+-record(mix_roster_channel, {participant_id = <<>> :: binary()}).
 -type mix_roster_channel() :: #mix_roster_channel{}.
 
 -record(roster_item, {jid :: jid:jid(),
@@ -926,7 +923,7 @@
 
 -record(roster_query, {items = [] :: [#roster_item{}],
                        ver :: 'undefined' | binary(),
-                       mix_annotate :: 'undefined' | #mix_roster_annotate{}}).
+                       mix_annotate = false :: boolean()}).
 -type roster_query() :: #roster_query{}.
 
 -record(xmpp_session, {optional = false :: boolean()}).
@@ -1356,7 +1353,6 @@
                         mix_leave() |
                         mix_participant() |
                         mix_presence() |
-                        mix_roster_annotate() |
                         mix_roster_channel() |
                         mix_setnick() |
                         mix_update_subscription() |

--- a/specs/xmpp_codec.spec
+++ b/specs/xmpp_codec.spec
@@ -96,7 +96,8 @@
            result = {roster_query, '$items', '$ver', '$mix_annotate'},
            attrs = [#attr{name = <<"ver">>, default = undefined}],
            refs = [#ref{name = roster_item, label = '$items'},
-                   #ref{name = mix_roster_annotate, label = '$mix_annotate', min = 0, max = 1}]}).
+                   #ref{name = mix_roster_annotate, label = '$mix_annotate',
+                        default = false, min = 0, max = 1}]}).
 
 -xml(rosterver_feature,
      #elem{name = <<"ver">>,
@@ -3615,7 +3616,7 @@
      #elem{name  = <<"annotate">>,
            xmlns = <<"urn:xmpp:mix:roster:0">>,
            module = 'xep0405',
-           result = {mix_roster_annotate}}).
+           result = true}).
 
 -xml(mix_presence,
      #elem{name = <<"mix">>,

--- a/specs/xmpp_codec.spec
+++ b/specs/xmpp_codec.spec
@@ -3608,8 +3608,8 @@
      #elem{name = <<"channel">>,
            xmlns = <<"urn:xmpp:mix:roster:0">>,
            module = 'xep0405',
-           result = {mix_roster_channel, '$participant-id'},
-           attrs = [#attr{name = <<"participant-id">>,
+           result = {mix_roster_channel, '$participant_id'},
+           attrs = [#attr{name = <<"participant-id">>, label = '$participant_id',
                           required = true}]}).
 
 -xml(mix_roster_annotate,

--- a/src/rfc6121.erl
+++ b/src/rfc6121.erl
@@ -91,7 +91,7 @@ decode_roster_query(__TopXMLNS, __Opts,
                                 __Opts,
                                 _els,
                                 [],
-                                undefined),
+                                false),
     Ver = decode_roster_query_attrs(__TopXMLNS,
                                     _attrs,
                                     undefined),
@@ -190,8 +190,8 @@ encode_roster_query({roster_query,
                                  [encode_roster_item(Items, __TopXMLNS)
                                   | _acc]).
 
-'encode_roster_query_$mix_annotate'(undefined,
-                                    __TopXMLNS, _acc) ->
+'encode_roster_query_$mix_annotate'(false, __TopXMLNS,
+                                    _acc) ->
     _acc;
 'encode_roster_query_$mix_annotate'(Mix_annotate,
                                     __TopXMLNS, _acc) ->

--- a/src/xep0405.erl
+++ b/src/xep0405.erl
@@ -56,42 +56,34 @@ do_encode({mix_client_leave, _, _, _} = Client_leave,
     encode_mix_client_leave(Client_leave, TopXMLNS);
 do_encode({mix_roster_channel, _} = Channel,
           TopXMLNS) ->
-    encode_mix_roster_channel(Channel, TopXMLNS);
-do_encode({mix_roster_annotate} = Annotate, TopXMLNS) ->
-    encode_mix_roster_annotate(Annotate, TopXMLNS).
+    encode_mix_roster_channel(Channel, TopXMLNS).
 
 do_get_name({mix_client_join, _, _, _}) ->
     <<"client-join">>;
 do_get_name({mix_client_leave, _, _, _}) ->
     <<"client-leave">>;
-do_get_name({mix_roster_annotate}) -> <<"annotate">>;
 do_get_name({mix_roster_channel, _}) -> <<"channel">>.
 
 do_get_ns({mix_client_join, _, _, Xmlns}) -> Xmlns;
 do_get_ns({mix_client_leave, _, _, Xmlns}) -> Xmlns;
-do_get_ns({mix_roster_annotate}) ->
-    <<"urn:xmpp:mix:roster:0">>;
 do_get_ns({mix_roster_channel, _}) ->
     <<"urn:xmpp:mix:roster:0">>.
 
 pp(mix_client_join, 3) -> [channel, join, xmlns];
 pp(mix_client_leave, 3) -> [channel, leave, xmlns];
-pp(mix_roster_channel, 1) -> ['participant-id'];
-pp(mix_roster_annotate, 0) -> [];
+pp(mix_roster_channel, 1) -> [participant_id];
 pp(_, _) -> no.
 
 records() ->
     [{mix_client_join, 3},
      {mix_client_leave, 3},
-     {mix_roster_channel, 1},
-     {mix_roster_annotate, 0}].
+     {mix_roster_channel, 1}].
 
 decode_mix_roster_annotate(__TopXMLNS, __Opts,
                            {xmlel, <<"annotate">>, _attrs, _els}) ->
-    {mix_roster_annotate}.
+    true.
 
-encode_mix_roster_annotate({mix_roster_annotate},
-                           __TopXMLNS) ->
+encode_mix_roster_annotate(true, __TopXMLNS) ->
     __NewTopXMLNS =
         xmpp_codec:choose_top_xmlns(<<"urn:xmpp:mix:roster:0">>,
                                     [],

--- a/src/xmpp_codec.erl
+++ b/src/xmpp_codec.erl
@@ -1701,7 +1701,10 @@ get_mod({pubsub,
 get_mod({x_conference, _, _, _, _, _}) -> xep0249;
 get_mod({inbox_query, _}) -> xep0430;
 get_mod({disco_info, _, _, _, _}) -> xep0030;
+get_mod({sm_a, _, _}) -> xep0198;
 get_mod({oob_x, _, _, _}) -> xep0066;
+get_mod({jingle_s5b_transport, _, _, _, _, _, _, _}) ->
+    xep0260;
 get_mod({privacy_query, _, _, _}) -> xep0016;
 get_mod({block, _}) -> xep0191;
 get_mod({vcard_label, _, _, _, _, _, _, _, _}) ->
@@ -1917,7 +1920,6 @@ get_mod({upload_request_0, _, _, _, _}) -> xep0363;
 get_mod({privacy_item, _, _, _, _, _, _, _, _}) ->
     xep0016;
 get_mod({starttls_failure}) -> rfc6120;
-get_mod({mix_roster_annotate}) -> xep0405;
 get_mod({bob_data, _, _, _, _}) -> xep0231;
 get_mod({markable}) -> xep0333;
 get_mod({bind, _, _}) -> rfc6120;
@@ -1979,7 +1981,4 @@ get_mod({bookmark_conference, _, _, _, _, _}) ->
 get_mod({vcard_name, _, _, _, _, _}) -> xep0054;
 get_mod({inbox_fin, _, _, _, _}) -> xep0430;
 get_mod({csi, _}) -> xep0352;
-get_mod({sm_a, _, _}) -> xep0198;
-get_mod({jingle_s5b_transport, _, _, _, _, _, _, _}) ->
-    xep0260;
 get_mod(Record) -> xmpp_codec_external:lookup(Record).


### PR DESCRIPTION
- mix_roster_annotate: Use boolean as result instead of empty record
- mix_participant: Rename 'participant-id' to participant_id