### PR TITLE
Use net:getaddrinfo for hostname resolution

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -22,6 +22,7 @@
 {erl_opts, [debug_info, {src_dirs, ["asn1", "src"]},
 	    nowarn_export_all,
             {platform_define, "^(R|1|20|21|22)", 'USE_OLD_CRYPTO_HMAC'},
+            {platform_define, "^(R|1|2[0123]|24\.[012])", 'USE_GETHOSTBYNAME'},
             {i, "include"}]}.
 
 {port_env, [{"ERL_LDFLAGS", " -L$ERL_EI_LIBDIR -lei"},

--- a/src/xmpp_socket.erl
+++ b/src/xmpp_socket.erl
@@ -122,7 +122,7 @@ connect(Addr, Port, Opts, Timeout) ->
     connect(Addr, Port, Opts, Timeout, self()).
 
 connect(Addr, Port, Opts, Timeout, Owner) ->
-    case gen_tcp:connect(Addr, Port, Opts, Timeout) of
+    case do_connect(Addr, Port, Opts, Timeout) of
 	{ok, Socket} ->
 	    SocketData = new(gen_tcp, Socket, []),
 	    case controlling_process(SocketData, Owner) of
@@ -136,6 +136,16 @@ connect(Addr, Port, Opts, Timeout, Owner) ->
 	{error, _Reason} = Error ->
 	    Error
     end.
+
+do_connect(Addr, Port, Opts, Timeout)
+    when is_tuple(Addr) orelse
+         is_list(Addr)  orelse
+         is_atom(Addr)  orelse
+         (Addr =:= any) orelse
+         (Addr =:= loopback) ->
+        gen_tcp:connect(Addr, Port, Opts, Timeout);
+do_connect(SockAddr, _Port, Opts, Timeout) ->
+        gen_tcp:connect(SockAddr, Opts, Timeout).
 
 -spec starttls(socket_state(), [proplists:property()]) ->
 		      {ok, socket_state()} |


### PR DESCRIPTION
getaddrinfo() returns an ordered list of addresses in preferred order, removing the need for destination address family selection/preference in applications. See [RFC 3484](https://www.ietf.org/rfc/rfc3484.html).

This uses it for outbound s2s connecions with OTP 24.3+ (when `gen_tcp:
connect(SockAddr, Opts, Timeout)` was introduced).