### PR TITLE
Use net:getaddrinfo for hostname resolution

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -21,8 +21,9 @@
 
 {erl_opts, [debug_info, {src_dirs, ["asn1", "src"]},
 	    nowarn_export_all,
-            {platform_define, "^(R|1|20|21|22)", 'USE_OLD_CRYPTO_HMAC'},
-            {platform_define, "^(R|1|2[0123]|24\.[012])", 'USE_GETHOSTBYNAME'},
+            {platform_define, "^(R|1|2[012])", 'USE_OLD_CRYPTO_HMAC'},
+            {platform_define, "^(R|1|2[01])", 'USE_GETHOSTBYNAME'},
+            {platform_define, "^(R|1|2[0123]|24\.[012])", 'USE_ADDRPORTCONNECT'},
             {i, "include"}]}.
 
 {port_env, [{"ERL_LDFLAGS", " -L$ERL_EI_LIBDIR -lei"},

--- a/src/xmpp_socket.erl
+++ b/src/xmpp_socket.erl
@@ -137,6 +137,7 @@ connect(Addr, Port, Opts, Timeout, Owner) ->
 	    Error
     end.
 
+-ifndef(USE_ADDRPORTCONNECT).
 do_connect(Addr, Port, Opts, Timeout)
     when is_tuple(Addr) orelse
          is_list(Addr)  orelse
@@ -146,6 +147,18 @@ do_connect(Addr, Port, Opts, Timeout)
         gen_tcp:connect(Addr, Port, Opts, Timeout);
 do_connect(SockAddr, _Port, Opts, Timeout) ->
         gen_tcp:connect(SockAddr, Opts, Timeout).
+-else.
+do_connect(Addr, Port, Opts, Timeout)
+    when is_tuple(Addr) orelse
+         is_list(Addr)  orelse
+         is_atom(Addr)  orelse
+         (Addr =:= any) orelse
+         (Addr =:= loopback) ->
+        gen_tcp:connect(Addr, Port, Opts, Timeout);
+do_connect(SockAddr, _Port, Opts, Timeout) ->
+        #{addr := Addr, port := Port} = SockAddr,
+        gen_tcp:connect(Addr, Port, Opts, Timeout).
+-endif.
 
 -spec starttls(socket_state(), [proplists:property()]) ->
 		      {ok, socket_state()} |


### PR DESCRIPTION
Where `gen_tcp:connect(SockAddr, Opts, Timeout)` is not available (OTP < 24.3), extract Addr & Port from SockAddr and connect to those.

As suggested in https://github.com/processone/xmpp/pull/71#issuecomment-1339454775

There are some  corner cases where this might not work 100% ie. when connecting to a link-local IPv6 address the scope_id should be specified but cannot be when using Address/Port variant of `gen_tcp:connect`. I doubt there are any real world examples of link-local IPv6 addresses used for XMPP servers though.