### PR TITLE
Increase the iteration count for SCRAM-SHA512 to 10000

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version xxx
+
+* Increase the iteration count for SCRAM-SHA-512 
+[see spec](https://datatracker.ietf.org/doc/html/draft-melnikov-scram-sha-512#name-security-considerations-3)
+
 # Version 1.8.0
 
 * Updating fast_tls to version 1.1.17.

--- a/include/scram.hrl
+++ b/include/scram.hrl
@@ -24,3 +24,5 @@
 -type scram() :: #scram{}.
 
 -define(SCRAM_DEFAULT_ITERATION_COUNT, 4096).
+% see https://datatracker.ietf.org/doc/html/draft-melnikov-scram-sha-512#name-security-considerations-3
+-define(SCRAM_SHA512_ITERATION_COUNT, 10000).

--- a/src/xmpp_sasl_scram.erl
+++ b/src/xmpp_sasl_scram.erl
@@ -136,16 +136,19 @@ mech_step(#state{step = 2, algo = Algo, ssdp = Ssdp} = State, ClientIn) ->
 					   base64:decode(SEK),
 					   base64:decode(Slt), IC};
 				      _ ->
+					  Iterations = if Algo =:= sha512 -> ?SCRAM_SHA512_ITERATION_COUNT;
+							   true -> ?SCRAM_DEFAULT_ITERATION_COUNT
+						       end,
 					  TempSalt =
 					  p1_rand:bytes(?SALT_LENGTH),
 					  SaltedPassword =
 					  scram:salted_password(Algo, Pass,
 								TempSalt,
-								?SCRAM_DEFAULT_ITERATION_COUNT),
+								Iterations),
 					  {scram:stored_key(Algo, scram:client_key(Algo, SaltedPassword)),
 					   scram:server_key(Algo, SaltedPassword),
 					   TempSalt,
-					   ?SCRAM_DEFAULT_ITERATION_COUNT}
+					   Iterations}
 				  end,
 				  ClientFirstMessageBare =
 				      substr(ClientIn,


### PR DESCRIPTION
The recommended iteration count has been increased to 10000 for SASL-SCRAM-SHA512 as stated [here](https://datatracker.ietf.org/doc/html/draft-melnikov-scram-sha-512#name-security-considerations-3)