### PR TITLE
specs: mix: Always use mix:core:1 xmlns for mix_participant

### DIFF
--- a/include/xmpp_codec.hrl
+++ b/include/xmpp_codec.hrl
@@ -955,9 +955,8 @@
 -record(x509_ca_list, {certs = [] :: [binary()]}).
 -type x509_ca_list() :: #x509_ca_list{}.
 
--record(mix_participant, {jid :: jid:jid(),
-                          nick = <<>> :: binary(),
-                          xmlns = <<>> :: binary()}).
+-record(mix_participant, {jid :: undefined | jid:jid(),
+                          nick :: 'undefined' | binary()}).
 -type mix_participant() :: #mix_participant{}.
 
 -record(compressed, {}).

--- a/specs/xmpp_codec.spec
+++ b/specs/xmpp_codec.spec
@@ -3559,17 +3559,11 @@
 
 -xml(mix_participant,
      #elem{name = <<"participant">>,
-	   xmlns = [<<"urn:xmpp:mix:core:0">>, <<"urn:xmpp:mix:core:1">>],
+	   xmlns = <<"urn:xmpp:mix:core:1">>,
 	   module = 'xep0369',
-	   result = {mix_participant, '$jid', '$nick', '$xmlns'},
-	   attrs = [#attr{name = <<"jid">>,
-			  required = true,
-			  label = '$jid',
-			  dec = {jid, decode, []},
-                          enc = {jid, encode, []}},
-		    #attr{name = <<"nick">>,
-			  label = '$nick'},
-		    #attr{name = <<"xmlns">>}]}).
+	   result = {mix_participant, '$jid', '$nick'},
+           refs = [#ref{name = mix_jid, min = 0, max = 1, label = '$jid'},
+                   #ref{name = mix_nick, min = 0, max = 1, label = '$nick'}]}).
 
 -xml(mix_create,
      #elem{name = <<"create">>,

--- a/src/xmpp_codec.erl
+++ b/src/xmpp_codec.erl
@@ -949,8 +949,6 @@ get_mod(<<"sm">>, <<"urn:xmpp:sm:3">>) -> xep0198;
 get_mod(<<"fetch">>,
         <<"http://jabber.org/protocol/offline">>) ->
     xep0013;
-get_mod(<<"participant">>, <<"urn:xmpp:mix:core:0">>) ->
-    xep0369;
 get_mod(<<"failed-transport">>,
         <<"urn:xmpp:jingle:1">>) ->
     xep0166;
@@ -1817,6 +1815,7 @@ get_mod({mix_roster_channel, _}) -> xep0405;
 get_mod({fasten_external, _}) -> xep0422;
 get_mod({shim, _}) -> xep0131;
 get_mod({mam_archived, _, _}) -> xep0313;
+get_mod({mix_participant, _, _}) -> xep0369;
 get_mod({delegated, _, _}) -> xep0355;
 get_mod({text, _, _}) -> xep0234;
 get_mod({muc_hat, _, _}) -> xep0317;
@@ -1966,7 +1965,6 @@ get_mod({sasl2_success, _, _, _}) -> xep0388;
 get_mod({stanza_error, _, _, _, _, _}) -> rfc6120;
 get_mod({sm_resumed, _, _, _}) -> xep0198;
 get_mod({offline_item, _, _}) -> xep0013;
-get_mod({mix_participant, _, _, _}) -> xep0369;
 get_mod({db_verify, _, _, _, _, _, _}) -> xep0220;
 get_mod({upload_slot, _, _, _}) -> xep0363;
 get_mod({jingle_ibb_transport, _, _, _}) -> xep0261;


### PR DESCRIPTION
The items from the participants node must have one specific namespace
and we cannot support both versions at the same time. The current
behaviour is to use the old mix:core:0 namespace (by default). This
changes the behaviour to always use the new mix:core:1 namespace.

