### PR TITLE
Include Makefile in hex.pm packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,10 +40,12 @@ clean:
 xref: all
 	$(REBAR) xref
 
+ifeq ($(MAKECMDGOALS),doap)
 xep_files := $(wildcard src/xep*.erl)
 xep_numbers := $(foreach i,$(xep_files),$(shell echo $(i) | sed 's|.*p\([0-9]*\).*|\1|g' | sort -u))
 xeps_missing := $(foreach i,$(xep_numbers),$(shell grep -q $(i) xmpp.doap || echo $(i)))
 xeps_missing2 := $(foreach i,$(xeps_missing),$(strip $(i)))
+endif
 
 doap:
 	@[ -z "$(xeps_missing2)" ] \
@@ -102,4 +104,4 @@ deps/fast_xml/ebin/fxml_gen.beam:
 ebin/xdata_codec.beam:
 	$(REBAR) get-deps compile
 
-.PHONY: clean src all spec xdata dialyzer erlang_plt deps_plt xmpp_plt
+.PHONY: clean src all spec xdata dialyzer erlang_plt deps_plt xmpp_plt doap

--- a/src/xmpp.app.src
+++ b/src/xmpp.app.src
@@ -34,7 +34,7 @@
   {env,          []},
 
   %% hex.pm packaging:
-  {files, ["src/", "specs/", "asn1/", "include/", "c_src/jid.c", "c_src/xmpp_uri.c", "c_src/xmpp_lang.c", "rebar.config", "rebar.config.script", "README.md", "LICENSE.txt"]},
+  {files, ["src/", "specs/", "asn1/", "include/", "c_src/jid.c", "c_src/xmpp_uri.c", "c_src/xmpp_lang.c", "rebar.config", "rebar.config.script", "README.md", "LICENSE.txt", "Makefile"]},
   {exclude_files, ["src/XmppAddr.erl", "src/XmppAddr.asn1db", "include/XmppAddr.hrl"]},
   {licenses, ["Apache 2.0"]},
   {links, [{"Github", "https://github.com/processone/xmpp"}]}]}.


### PR DESCRIPTION
Projects that have a dependency on xmpp can build custom specs with this:

```
make -C _build/default/lib/xmpp USE_REBAR3=1 FXML_GEN_DIR=$(pwd)/specs spec
```

But this currently only works if the xmpp depdenency is pulled from git, as the hex.pm package does not include the necessary `Makefile` - so this adds it to the package.

This commit also updates the `Makefile` to only check `xmpp.doap` when requested by using the `doap` goal, which eliminates a lot of 'File not found' noise when `make` is invoked outside of the source tree (or with hex.pm package, as that also does not include xmpp.doap)